### PR TITLE
Add support for Xcode 11 projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,16 @@
 
 This step will simply read Xcode Project Info data from `Info.plist` file,
 then export that data to environment variables prefixed with **XPI_**.
+For Xcode 11 projects, it will read the version number from the xcodeproj folder instead.
 
 After this you can use these environment variables in other steps (ex. sending message on Slack).
 
 ## Outputs
 
-Env Var | Description
------------- | -------------
-`$XPI_VERSION` | Version (CFBundleShortVersionString from Info.plist)
-`$XPI_BUILD` | Build (CFBundleVersion from Info.plist)
+| Env Var        | Description                                          |
+| -------------- | ---------------------------------------------------- |
+| `$XPI_VERSION` | Version (CFBundleShortVersionString from Info.plist) |
+| `$XPI_BUILD`   | Build (CFBundleVersion from Info.plist)              |
 
 ## How to use this Step
 
@@ -21,3 +22,6 @@ You just need to set relative path from Source directory to `Info.plist` file.
 Source directory is considered to be root directory created by the Git Clone step.
 If your `Info.plist` file is in **RootDir/ProjectName** directory (for example), 
 then you should set this input to `ProjectName/Info.plist`.
+
+For Xcode 11 projects, you will need to set the relative path from source directory to the `.xcodeproj` directory.
+Additionally, you can specify which target you want to get the version from.

--- a/README.md
+++ b/README.md
@@ -24,4 +24,5 @@ If your `Info.plist` file is in **RootDir/ProjectName** directory (for example),
 then you should set this input to `ProjectName/Info.plist`.
 
 For Xcode 11 projects, you will need to set the relative path from source directory to the `.xcodeproj` directory.
-Additionally, you can specify which target you want to get the version from.
+Additionally, you can specify which target you want to get the version & build numbers for.
+If actual values are set in Info.plist, they will be used instead of the values from the xcodeproj. This means it won't break if you set a build number within your workflow for instance.

--- a/step.sh
+++ b/step.sh
@@ -16,6 +16,8 @@ fi
 # ---------------------
 # --- Main
 
+ORIGIN_PATH=$(pwd)
+
 DIRECTORY=$(dirname "${info_plist_path}")
 FILENAME=$(basename "${info_plist_path}")
 
@@ -32,6 +34,22 @@ echo "[INFO] Reading data from [${info_plist_path}]..."
 
 version=$(/usr/libexec/PlistBuddy -c "Print CFBundleShortVersionString" "${FILENAME}")
 build=$(/usr/libexec/PlistBuddy -c "Print CFBundleVersion" "${FILENAME}")
+
+if [ $version=='$(MARKETING_VERSION)' ]; then
+	echo "[INFO] Xcode 11+ project detected, reading version number from xcodeproj instead..."
+	cd "${ORIGIN_PATH}"
+	if [ -z "${xcodeproj_path}" ]; then
+		echo "[ERROR] Please provide correct path to the xcodeproj folder"
+		exit 1
+	fi
+	if [ -z "${target}" ]; then
+		TARGET_SPECIFIER=""
+	else
+		TARGET_SPECIFIER="-target '${target}'"
+	fi
+	echo "[INFO] Reading data from [${xcodeproj_path}]..."
+	version=$(/bin/sh -c "xcodebuild -project ${xcodeproj_path} $TARGET_SPECIFIER -showBuildSettings" | grep "MARKETING_VERSION" | sed 's/[ ]*MARKETING_VERSION = //')
+fi
 
 envman add --key XPI_VERSION --value "${version}"
 echo "[INFO] Version: ${version} -> Saved to \$XPI_VERSION environment variable."

--- a/step.yml
+++ b/step.yml
@@ -4,6 +4,8 @@ description: |-
   This step will simply read Xcode Project Info data from `Info.plist` file,
   then export that data to environment variables prefixed with **XPI_**.
 
+  For Xcode 11 projects, it will read the version number from the pbxproj file.
+
   After this you can use these environment variables in other steps (ex. sending message on Slack).
 website: https://github.com/tadija/bitrise-step-xcode-project-info
 source_code_url: https://github.com/tadija/bitrise-step-xcode-project-info
@@ -20,7 +22,7 @@ is_always_run: false
 is_skippable: false
 deps:
   check_only:
-  - name: xcode
+    - name: xcode
 inputs:
   - info_plist_path: Info.plist
     opts:
@@ -31,6 +33,21 @@ inputs:
         then you should set this input to `ProjectName/Info.plist`.
       summary: ""
       is_required: true
+  - xcodeproj_path:
+    opts:
+      title: "Relative path from Source directory to the xcodeproj folder file (necessary for Xcode 11+ projects)"
+      description: |-
+        From Xcode 11, the version number is no longer stored in Info.plist, but replaced by the variable $(MARKETING_VERSION).
+        The actual version number should be extracted from the pbxproj file.
+      summary: ""
+      is_required: false
+  - target:
+    opts:
+      title: "For Xcode 11+ projects, get the version for this target"
+      description: |-
+        The version can differ depending on the target. If not specified, the default target will be used.
+      summary: ""
+      is_required: false
 outputs:
   - XPI_VERSION:
     opts:

--- a/step.yml
+++ b/step.yml
@@ -37,15 +37,15 @@ inputs:
     opts:
       title: "Relative path from Source directory to the xcodeproj folder file (necessary for Xcode 11+ projects)"
       description: |-
-        From Xcode 11, the version number is no longer stored in Info.plist, but replaced by the variable $(MARKETING_VERSION).
-        The actual version number should be extracted from the pbxproj file.
+        From Xcode 11, the version & build numbers are no longer stored in Info.plist, but replaced by the variables $(MARKETING_VERSION) and $(CURRENT_PROJECT_VERSION).
+        The actual numbers should be extracted from the pbxproj file.
       summary: ""
       is_required: false
   - target:
     opts:
-      title: "For Xcode 11+ projects, get the version for this target"
+      title: "For Xcode 11+ projects, get the version & build for this target"
       description: |-
-        The version can differ depending on the target. If not specified, the default target will be used.
+        The version & build number can differ depending on the target. If not specified, the default target will be used.
       summary: ""
       is_required: false
 outputs:


### PR DESCRIPTION
Linked to issue #2 

In Xcode 11, the version string is no longer stored in Info.plist. Instead, it is stored in the project files and replaced at buildtime through the `$(MARKETING_VERSION)` variable.

This PR checks after retrieving the version from Info.plist, if it equals the string `$(MARKETING_VERSION)`, and if so, will attempt to get the actual version number using `xcodebuild`.

In order to do that we need the user to provide the path to the `xcodeproj` folder.
Optionally, The user can specify a target from which the version should be extracted, as they can differ across targets. If nothing is specified it will use the default target.

Tested and working on our projects (workspace with several targets), but could probably use a bit more testing with more diverse types of projects.